### PR TITLE
Добавляет defront.ru

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [Саша Беспоясов](https://bespoyasov.ru/blog/), [RSS](https://bespoyasov.ru/rss.xml)
 - [Марат Таналин](https://tanalin.com/blog/), [RSS](https://tanalin.com/blog/feeds/rss/)
 - [Это блог](https://isqua.ru/blog/), [RSS](https://isqua.ru/blog/rss/)
+- [Defront](https://defront.ru/), [RSS](https://defront.ru/feed/feed.xml)
 
 ## Англоязычные
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@
 ## Русскоязычные
 
 - [CSS-live](https://css-live.ru/), [RSS](https://css-live.ru/feed/)
-- [Веб-стандарты](https://web-standards.ru/articles/), [RSS](https://web-standards.ru/articles/feed/)
-- [Саша Беспоясов](https://bespoyasov.ru/blog/), [RSS](https://bespoyasov.ru/rss.xml)
-- [Марат Таналин](https://tanalin.com/blog/), [RSS](https://tanalin.com/blog/feeds/rss/)
-- [Это блог](https://isqua.ru/blog/), [RSS](https://isqua.ru/blog/rss/)
 - [Defront](https://defront.ru/), [RSS](https://defront.ru/feed/feed.xml)
+- [Веб-стандарты](https://web-standards.ru/articles/), [RSS](https://web-standards.ru/articles/feed/)
+- [Марат Таналин](https://tanalin.com/blog/), [RSS](https://tanalin.com/blog/feeds/rss/)
+- [Саша Беспоясов](https://bespoyasov.ru/blog/), [RSS](https://bespoyasov.ru/rss.xml)
+- [Это блог](https://isqua.ru/blog/), [RSS](https://isqua.ru/blog/rss/)
 
 ## Англоязычные
 


### PR DESCRIPTION
Привет! Defront.ru — это блог, над которым я работаю с 2019 года. В основном пишу про фротенд, веб-стандарты и иногда про безопасность. Большинство постов в блоге — это короткие пересказы прочитанных статей, но также иногда пишу свои статьи.